### PR TITLE
feat(competences-pagination): add muted state for pagination buttons

### DIFF
--- a/assets/css/competences.css
+++ b/assets/css/competences.css
@@ -53,8 +53,11 @@ div.competence-pagination-fleche > img{
     height: 6.7px;
 }
 
-div#competence-pagination-gauche > img{
+#competence-pagination-gauche > img{
     rotate: 180deg;
+}
+
+.muted{
     opacity: .7;
 }
 

--- a/assets/js/competences/classes/pagination.js
+++ b/assets/js/competences/classes/pagination.js
@@ -48,7 +48,11 @@ class Pagination{
         if(this.index === this.nbTotalPages){
             return;
         }
-        document.getElementById(`carousel-item-${this.index}`).style.display = "none";
+        if(this.index === this.nbTotalPages - 1){
+            document.getElementById('competence-pagination-right-arrow').classList.add('muted');
+        }
+        document.getElementById('competence-pagination-left-arrow').classList.remove('muted');
+        document.getElementById(`carousel-item-${this.index}`).style.display = 'none';
         this.index++;
         this.updateHTMLIndex();
     }
@@ -60,6 +64,10 @@ class Pagination{
         if(this.index === 1){
             return;
         }
+        if(this.index === 2){
+            document.getElementById('competence-pagination-left-arrow').classList.add('muted');
+        }
+        document.getElementById('competence-pagination-right-arrow').classList.remove('muted');
         document.getElementById(`carousel-item-${this.index-1}`).style.display = "";
         this.index--;
         this.updateHTMLIndex();

--- a/index.html
+++ b/index.html
@@ -138,27 +138,27 @@
             </div>
 
             <div id="competence-pagination-gauche" class="competence-pagination-fleche">
-                <img src="assets/img/Icon awesome-long-arrow-alt-right.svg" alt="fleche pointant vers la gauche">
+                <img src="./assets/img/Icon awesome-long-arrow-alt-right.svg" id="competence-pagination-left-arrow" alt="fleche pointant vers la gauche" class="muted">
             </div>
             <div id="competence-pagination-droite" class="competence-pagination-fleche">
-                <img src="assets/img/Icon awesome-long-arrow-alt-right.svg" alt="fleche pointant vers la droite">
+                <img src="./assets/img/Icon awesome-long-arrow-alt-right.svg" id="competence-pagination-right-arrow" alt="fleche pointant vers la droite">
             </div>
         </div>
 
         <div id="competence-titre-container">
             <h3 id="competence-titre">BOOSTER VOS COMPÉTENCES</h3>
-            <img id="competence-titre-fleche" src="assets/img/Icon feather-arrow-right.svg" alt="flèche pointant vers la droite">
+            <img id="competence-titre-fleche" src="./assets/img/Icon feather-arrow-right.svg" alt="flèche pointant vers la droite">
         </div>
 
         <div id="competence-carousel">
 
             <div id="carousel-item-1" class="competence-carousel-item">
-                <div class="competence-carousel-item-image" style="background: url('/assets/img/shutterstock_421594822.png')">
+                <div class="competence-carousel-item-image" style="background: url('./assets/img/shutterstock_421594822.png')">
                     <div class="competence-carousel-item-fond-bleu"></div>
                     <span class="competence-carousel-item-title">
                         LOREM IPSUM IS SIMPLY DUMMY TEXT OF THE PRINTING
                     </span>
-                    <img class="competence-carousel-item-fleche" src="assets/img/Icon feather-arrow-right.svg" alt="flèche pointant vers la droite">
+                    <img class="competence-carousel-item-fleche" src="./assets/img/Icon feather-arrow-right.svg" alt="flèche pointant vers la droite">
                 </div>
                 <span class="competence-carousel-item-subtitle">
                     Evènement
@@ -166,12 +166,12 @@
             </div>
 
             <div id="carousel-item-2" class="competence-carousel-item">
-                <div class="competence-carousel-item-image" style="background: url('/assets/img/shutterstock_703607812.png')">
+                <div class="competence-carousel-item-image" style="background: url('./assets/img/shutterstock_703607812.png')">
                     <div class="competence-carousel-item-fond-bleu"></div>
                     <span class="competence-carousel-item-title">
                         LOREM IPSUM IS SIMPLY DUMMY TEXT OF THE PRINTING
                     </span>
-                    <img class="competence-carousel-item-fleche" src="assets/img/Icon feather-arrow-right.svg" alt="flèche pointant vers la droite">
+                    <img class="competence-carousel-item-fleche" src="./assets/img/Icon feather-arrow-right.svg" alt="flèche pointant vers la droite">
                 </div>
                 <span class="competence-carousel-item-subtitle">
                     Atelier
@@ -179,12 +179,12 @@
             </div>
 
             <div id="carousel-item-3" class="competence-carousel-item">
-                <div class="competence-carousel-item-image" style="background: url('/assets/img/shutterstock_1727886613.png')">
+                <div class="competence-carousel-item-image" style="background: url('./assets/img/shutterstock_1727886613.png')">
                     <div class="competence-carousel-item-fond-bleu"></div>
                     <span class="competence-carousel-item-title">
                         LOREM IPSUM IS SIMPLY DUMMY TEXT OF THE PRINTING
                     </span>
-                    <img class="competence-carousel-item-fleche" src="assets/img/Icon feather-arrow-right.svg" alt="flèche pointant vers la droite">
+                    <img class="competence-carousel-item-fleche" src="./assets/img/Icon feather-arrow-right.svg" alt="flèche pointant vers la droite">
                 </div>
                 <span class="competence-carousel-item-subtitle">
                     Atelier
@@ -192,12 +192,12 @@
             </div>
 
             <div id="carousel-item-4" class="competence-carousel-item">
-                <div class="competence-carousel-item-image" style="background: url('/assets/img/shutterstock_1414838378.png')">
+                <div class="competence-carousel-item-image" style="background: url('./assets/img/shutterstock_1414838378.png')">
                     <div class="competence-carousel-item-fond-bleu"></div>
                     <span class="competence-carousel-item-title">
                         LOREM IPSUM IS SIMPLY DUMMY TEXT OF THE PRINTING
                     </span>
-                    <img class="competence-carousel-item-fleche" src="assets/img/Icon feather-arrow-right.svg" alt="flèche pointant vers la droite">
+                    <img class="competence-carousel-item-fleche" src="./assets/img/Icon feather-arrow-right.svg" alt="flèche pointant vers la droite">
                 </div>
                 <span class="competence-carousel-item-subtitle">
                     Séminaire
@@ -205,12 +205,12 @@
             </div>
 
             <div id="carousel-item-5" class="competence-carousel-item">
-                <div class="competence-carousel-item-image" style="background: url('/assets/img/shutterstock_421594822.png')">
+                <div class="competence-carousel-item-image" style="background: url('./assets/img/shutterstock_421594822.png')">
                     <div class="competence-carousel-item-fond-bleu"></div>
                     <span class="competence-carousel-item-title">
                         LOREM IPSUM IS SIMPLY DUMMY TEXT OF THE PRINTING
                     </span>
-                    <img class="competence-carousel-item-fleche" src="assets/img/Icon feather-arrow-right.svg" alt="flèche pointant vers la droite">
+                    <img class="competence-carousel-item-fleche" src="./assets/img/Icon feather-arrow-right.svg" alt="flèche pointant vers la droite">
                 </div>
                 <span class="competence-carousel-item-subtitle">
                     Evènement
@@ -218,12 +218,12 @@
             </div>
 
             <div id="carousel-item-6" class="competence-carousel-item">
-                <div class="competence-carousel-item-image" style="background: url('/assets/img/shutterstock_703607812.png')">
+                <div class="competence-carousel-item-image" style="background: url('./assets/img/shutterstock_703607812.png')">
                     <div class="competence-carousel-item-fond-bleu"></div>
                     <span class="competence-carousel-item-title">
                         LOREM IPSUM IS SIMPLY DUMMY TEXT OF THE PRINTING
                     </span>
-                    <img class="competence-carousel-item-fleche" src="assets/img/Icon feather-arrow-right.svg" alt="flèche pointant vers la droite">
+                    <img class="competence-carousel-item-fleche" src="./assets/img/Icon feather-arrow-right.svg" alt="flèche pointant vers la droite">
                 </div>
                 <span class="competence-carousel-item-subtitle">
                     Atelier
@@ -231,12 +231,12 @@
             </div>
 
             <div id="carousel-item-7" class="competence-carousel-item">
-                <div class="competence-carousel-item-image" style="background: url('/assets/img/shutterstock_1727886613.png')">
+                <div class="competence-carousel-item-image" style="background: url('./assets/img/shutterstock_1727886613.png')">
                     <div class="competence-carousel-item-fond-bleu"></div>
                     <span class="competence-carousel-item-title">
                         LOREM IPSUM IS SIMPLY DUMMY TEXT OF THE PRINTING
                     </span>
-                    <img class="competence-carousel-item-fleche" src="assets/img/Icon feather-arrow-right.svg" alt="flèche pointant vers la droite">
+                    <img class="competence-carousel-item-fleche" src="./assets/img/Icon feather-arrow-right.svg" alt="flèche pointant vers la droite">
                 </div>
                 <span class="competence-carousel-item-subtitle">
                     Atelier
@@ -244,12 +244,12 @@
             </div>
 
             <div id="carousel-item-8" class="competence-carousel-item">
-                <div class="competence-carousel-item-image" style="background: url('/assets/img/shutterstock_1414838378.png')">
+                <div class="competence-carousel-item-image" style="background: url('./assets/img/shutterstock_1414838378.png')">
                     <div class="competence-carousel-item-fond-bleu"></div>
                     <span class="competence-carousel-item-title">
                         LOREM IPSUM IS SIMPLY DUMMY TEXT OF THE PRINTING
                     </span>
-                    <img class="competence-carousel-item-fleche" src="assets/img/Icon feather-arrow-right.svg" alt="flèche pointant vers la droite">
+                    <img class="competence-carousel-item-fleche" src="./assets/img/Icon feather-arrow-right.svg" alt="flèche pointant vers la droite">
                 </div>
                 <span class="competence-carousel-item-subtitle">
                     Séminaire


### PR DESCRIPTION
This PR add updated muted state for arrows on navigation button on the competences section.

![image](https://github.com/user-attachments/assets/8d401ad9-37d6-44b1-b15b-867f89d202a6)
